### PR TITLE
Fix #3 for 1.19.2

### DIFF
--- a/src/main/java/com/darkere/moredragoneggs/MoreDragonEggs.java
+++ b/src/main/java/com/darkere/moredragoneggs/MoreDragonEggs.java
@@ -1,5 +1,6 @@
 package com.darkere.moredragoneggs;
 
+import com.darkere.moredragoneggs.mixin.EndDragonFightAccess;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.TickTask;
@@ -7,6 +8,9 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.WallSkullBlock;
+import net.minecraft.world.level.dimension.end.EndDragonFight;
+import net.minecraft.world.level.levelgen.Heightmap;
+import net.minecraft.world.level.levelgen.feature.EndPodiumFeature;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
@@ -59,4 +63,15 @@ public class MoreDragonEggs {
     }
 
 
+    public static void placeAdditionalEggAndMaybeHead(EndDragonFight dragonFight) {
+        ServerLevel level = ((EndDragonFightAccess)dragonFight).moredragoneggs_getLevel();
+        BlockPos pos = level.getHeightmapPos(Heightmap.Types.MOTION_BLOCKING, EndPodiumFeature.END_PODIUM_LOCATION);
+        while (level.getBlockState(pos).getBlock() != Blocks.AIR){
+            pos = pos.above();
+        }
+        if (dragonFight.hasPreviouslyKilledDragon()) {
+            level.setBlockAndUpdate(pos, Blocks.DRAGON_EGG.defaultBlockState());
+        }
+        PlaceDragonHead( pos, level);
+    }
 }

--- a/src/main/java/com/darkere/moredragoneggs/mixin/DragonEggMixin.java
+++ b/src/main/java/com/darkere/moredragoneggs/mixin/DragonEggMixin.java
@@ -1,16 +1,9 @@
 package com.darkere.moredragoneggs.mixin;
 
 import com.darkere.moredragoneggs.MoreDragonEggs;
-import net.minecraft.core.BlockPos;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.boss.enderdragon.EnderDragon;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.dimension.end.EndDragonFight;
-import net.minecraft.world.level.levelgen.Heightmap;
-import net.minecraft.world.level.levelgen.feature.EndPodiumFeature;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -18,29 +11,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(EndDragonFight.class)
 public class DragonEggMixin {
 
-    @Shadow
-    private
-    boolean previouslyKilled;
-    @Shadow
-    @Final
-    private
-    ServerLevel level;
-
-
     @Inject(at = @At("HEAD"),method = "setDragonKilled(Lnet/minecraft/world/entity/boss/enderdragon/EnderDragon;)V")
     private void setDragonKilled(EnderDragon p_64086_, CallbackInfo cb) {
-        placeAdditionalEggAndMaybeHead();
-    }
-
-    protected void placeAdditionalEggAndMaybeHead() {
-        BlockPos pos = this.level.getHeightmapPos(Heightmap.Types.MOTION_BLOCKING, EndPodiumFeature.END_PODIUM_LOCATION);
-        while (this.level.getBlockState(pos).getBlock() != Blocks.AIR){
-            pos = pos.above();
-        }
-        if (this.previouslyKilled) {
-            this.level.setBlockAndUpdate(pos, Blocks.DRAGON_EGG.defaultBlockState());
-        }
-        MoreDragonEggs.PlaceDragonHead( pos, this.level);
+        MoreDragonEggs.placeAdditionalEggAndMaybeHead((EndDragonFight)(Object)this);
     }
 
 }

--- a/src/main/java/com/darkere/moredragoneggs/mixin/DragonEggMixin.java
+++ b/src/main/java/com/darkere/moredragoneggs/mixin/DragonEggMixin.java
@@ -29,7 +29,14 @@ public class DragonEggMixin {
 
     @Inject(at = @At("HEAD"),method = "setDragonKilled(Lnet/minecraft/world/entity/boss/enderdragon/EnderDragon;)V")
     private void setDragonKilled(EnderDragon p_64086_, CallbackInfo cb) {
+        placeAdditionalEggAndMaybeHead();
+    }
+
+    protected void placeAdditionalEggAndMaybeHead() {
         BlockPos pos = this.level.getHeightmapPos(Heightmap.Types.MOTION_BLOCKING, EndPodiumFeature.END_PODIUM_LOCATION);
+        while (this.level.getBlockState(pos).getBlock() != Blocks.AIR){
+            pos = pos.above();
+        }
         if (this.previouslyKilled) {
             this.level.setBlockAndUpdate(pos, Blocks.DRAGON_EGG.defaultBlockState());
         }

--- a/src/main/java/com/darkere/moredragoneggs/mixin/EndDragonFightAccess.java
+++ b/src/main/java/com/darkere/moredragoneggs/mixin/EndDragonFightAccess.java
@@ -1,0 +1,13 @@
+package com.darkere.moredragoneggs.mixin;
+
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.dimension.end.EndDragonFight;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(EndDragonFight.class)
+public interface EndDragonFightAccess {
+
+    @Accessor("level")
+    ServerLevel moredragoneggs_getLevel();
+}

--- a/src/main/java/com/darkere/moredragoneggs/mixin/EndergeticDragonEggMixin.java
+++ b/src/main/java/com/darkere/moredragoneggs/mixin/EndergeticDragonEggMixin.java
@@ -1,0 +1,19 @@
+package com.darkere.moredragoneggs.mixin;
+
+import net.minecraft.world.entity.boss.enderdragon.EnderDragon;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Pseudo
+@Mixin(targets = "com.teamabnormals.endergetic.common.world.EndergeticDragonFightManager")
+public class EndergeticDragonEggMixin extends DragonEggMixin {
+
+
+    @Inject(at = @At("HEAD"),method = "setDragonKilled(Lnet/minecraft/world/entity/boss/enderdragon/EnderDragon;)V")
+    private void setDragonKilled(EnderDragon p_64086_, CallbackInfo cb) {
+        this.placeAdditionalEggAndMaybeHead();
+    }
+}

--- a/src/main/java/com/darkere/moredragoneggs/mixin/EndergeticDragonEggMixin.java
+++ b/src/main/java/com/darkere/moredragoneggs/mixin/EndergeticDragonEggMixin.java
@@ -1,6 +1,10 @@
 package com.darkere.moredragoneggs.mixin;
 
+import com.darkere.moredragoneggs.MoreDragonEggs;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.boss.enderdragon.EnderDragon;
+import net.minecraft.world.level.dimension.end.EndDragonFight;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.injection.At;
@@ -9,11 +13,14 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Pseudo
 @Mixin(targets = "com.teamabnormals.endergetic.common.world.EndergeticDragonFightManager")
-public class EndergeticDragonEggMixin extends DragonEggMixin {
+public class EndergeticDragonEggMixin extends EndDragonFight {
 
+    public EndergeticDragonEggMixin(ServerLevel level, long seed, CompoundTag fightData) {
+        super(level, seed, fightData);
+    }
 
     @Inject(at = @At("HEAD"),method = "setDragonKilled(Lnet/minecraft/world/entity/boss/enderdragon/EnderDragon;)V")
     private void setDragonKilled(EnderDragon p_64086_, CallbackInfo cb) {
-        this.placeAdditionalEggAndMaybeHead();
+        MoreDragonEggs.placeAdditionalEggAndMaybeHead(this);
     }
 }

--- a/src/main/resources/mixins.moredragoneggs.json
+++ b/src/main/resources/mixins.moredragoneggs.json
@@ -5,6 +5,7 @@
   "refmap": "mixins.moredragoneggs.refmap.json",
   "mixins": [
     "DragonEggMixin",
+    "EndDragonFightAccess",
     "EndergeticDragonEggMixin"
   ],
   "minVersion": "0.8"

--- a/src/main/resources/mixins.moredragoneggs.json
+++ b/src/main/resources/mixins.moredragoneggs.json
@@ -3,6 +3,9 @@
   "package": "com.darkere.moredragoneggs.mixin",
   "compatibilityLevel": "JAVA_17",
   "refmap": "mixins.moredragoneggs.refmap.json",
-  "mixins": ["DragonEggMixin"],
+  "mixins": [
+    "DragonEggMixin",
+    "EndergeticDragonEggMixin"
+  ],
   "minVersion": "0.8"
 }


### PR DESCRIPTION
The fix detailed in #3 was implemented. Additionally, the original Mixin was extended since Endergetic Expansion 1.19.2 replaces the EnderDragonFight with its own custom extension. EE 1.19.2 can be obtained from their Github if you need to test.

Note: The optional placement of an Ender Dragon head does not work with EE. I was only asked to fix the egg issue, so I have no plans to fix the dragon head myself with this PR.